### PR TITLE
Improve the CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,24 @@ Copy the `config.sample.yaml` to `config.yaml` and change your props as api toke
 ### Github
 - Go to https://github.com/settings/tokens
 - Click **Generate new token**
-- Enter Note & check repo in **select scopes**
+- Enter Note & check `repo` in **select scopes**
 
 Enter credentials into `config.yaml`
 
 ## Installation
 
-    composer install
-    php cli.php
+```shell
+composer install
+```
 
-## CLI Commands
+## Usage
 
-    mantis2github  creates a github issue from a mantis issue
+```shell
+php mantis2github [command]
+```
+
+### Available Commands
+
+    sync           creates a github issue from a mantis issue
     github-read    read details of a github issue
     mantis-read    read details of a mantis issue

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ php mantis2github [command]
 
 ### Available Commands
 
-    sync           creates a github issue from a mantis issue
-    github-read    read details of a github issue
-    mantis-read    read details of a mantis issue
+| Command       | Description                               |
+|---------------|-------------------------------------------|
+| `sync`        | Create a GitHub Issue from a Mantis Issue |
+| `github-read` | Read details of a GitHub Issue            |
+| `mantis-read` | Read details of a Mantis Issue            |

--- a/mantis2github
+++ b/mantis2github
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 /*
  * This file is part of the Artemeon Core - Web Application Framework.

--- a/src/Command/ReadGithubIssueCommand.php
+++ b/src/Command/ReadGithubIssueCommand.php
@@ -13,6 +13,7 @@ namespace Artemeon\M2G\Command;
 use Artemeon\M2G\Service\GithubConnector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -40,7 +41,7 @@ class ReadGithubIssueCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Github Details');
-        $question = new Question('Github Issue ID:');
+        $question = new Question('Github Issue ID: ');
         /** @var QuestionHelper $helper */
         $helper = $this->getHelper('question');
         $id = $helper->ask($input, $output, $question);
@@ -51,11 +52,12 @@ class ReadGithubIssueCommand extends Command
 
         $issue = $this->githubConnector->readIssue((int)$id);
 
-        $output->writeln('------------------------------------------');
-        $output->writeln('ID:              ' . $issue->getId());
-        $output->writeln('Number:          ' . $issue->getNumber());
-        $output->writeln('Summary:         ' . $issue->getTitle());
-        $output->writeln('------------------------------------------');
+        $table = new Table($output);
+        $table->addRow(['ID', $issue->getId()]);
+        $table->addRow(['Number', '#' . $issue->getNumber()]);
+        $table->addRow(['Title', $issue->getTitle()]);
+        $table->addRow(['URL', $issue->getIssueUrl()]);
+        $table->render();
 
         return 0;
     }

--- a/src/Command/ReadMantisIssueCommand.php
+++ b/src/Command/ReadMantisIssueCommand.php
@@ -14,6 +14,7 @@ use Artemeon\M2G\Service\GithubConnector;
 use Artemeon\M2G\Service\MantisConnector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -38,7 +39,7 @@ class ReadMantisIssueCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Mantis Details');
-        $question = new Question('Mantis ID:');
+        $question = new Question('Mantis ID: ');
         /** @var QuestionHelper $helper */
         $helper = $this->getHelper('question');
         $id = $helper->ask($input, $output, $question);
@@ -49,11 +50,11 @@ class ReadMantisIssueCommand extends Command
 
         $issue = $this->mantisConnector->readIssue((int)$id);
 
-        $output->writeln('------------------------------------------');
-        $output->writeln('ID:              ' . $issue->getId());
-        $output->writeln('Summary:         ' . $issue->getSummary());
-        $output->writeln('Upstream Ticket: ' . $issue->getUpstreamTicket());
-        $output->writeln('------------------------------------------');
+        $table = new Table($output);
+        $table->addRow(['ID', $issue->getId()]);
+        $table->addRow(['Summary', $issue->getSummary()]);
+        $table->addRow(['GitHub Issue URL', $issue->getUpstreamTicket()]);
+        $table->render();
 
         return 0;
     }

--- a/src/Service/GithubConnector.php
+++ b/src/Service/GithubConnector.php
@@ -30,15 +30,13 @@ class GithubConnector
 
         $result = json_decode($response->getBody(), true);
 
-        $issue = new GithubIssue(
+        return new GithubIssue(
             $result['id'],
             $result['number'],
             $result['title'],
-            $result['body'],
+            $result['body'] ?? '',
             'https://github.com/' . $this->config->getGithubRepo() . '/issues/' . $result['number']
         );
-
-        return $issue;
     }
 
 

--- a/src/Service/MantisConnector.php
+++ b/src/Service/MantisConnector.php
@@ -23,10 +23,14 @@ class MantisConnector
         $this->config = $config;
     }
 
-    public function readIssue(int $number): MantisIssue
+    public function readIssue(int $number): ?MantisIssue
     {
-        $response = $this->getDefaultClient()->get(rtrim($this->config->getMantisUrl(),'/') . '/api/rest/issues/' . $number);
-        $result = json_decode($response->getBody(), true);
+        try {
+            $response = $this->getDefaultClient()->get(rtrim($this->config->getMantisUrl(),'/') . '/api/rest/issues/' . $number);
+            $result = json_decode($response->getBody(), true);
+        } catch (\Exception $e) {
+            return null;
+        }
 
         $issue = new MantisIssue(
             $result['issues'][0]['id'],


### PR DESCRIPTION
- Improves the CLI output with tables.
- Changes the general signature from `php cli.php [command]` to `php mantis2github [command]`
  - `php cli.php mantis2github` changes to `php mantis2github sync`
- Adds error handling (if mantis issue not found).
- The sync command now prompts you with the found Mantis issue (summary) and asks if you really want to create a new GitHub issue.